### PR TITLE
Add support for already formatted markdown links

### DIFF
--- a/lib/vimwiki_markdown/wiki_body.rb
+++ b/lib/vimwiki_markdown/wiki_body.rb
@@ -31,6 +31,12 @@ class VimwikiMarkdown::WikiBody
   end
 
   def fixlinks
+    # convert links that are already markdown to include html extension
+    @markdown_body.gsub!(/\[(.*?)\]\((.*?)\)/) do
+      link_text = Regexp.last_match[1]
+      link_title = Regexp.last_match[2]
+      "[#{link_text}](#{link_title.parameterize}.html)"
+    end
     #convert wiki_links to markdown links
     # [This link](http://example.net/)
     @markdown_body.gsub!(/\[\[(.*?)\]\]/) do


### PR DESCRIPTION
If vimwiki/vimwiki#186 is merged, this should ensure compatibility once real markdown links are supported.

I don't really know ruby so make sure I did this right :)