### PR TITLE
add simple support for %root_path% substitutions in template

### DIFF
--- a/lib/vimwiki_markdown/template.rb
+++ b/lib/vimwiki_markdown/template.rb
@@ -26,12 +26,17 @@ module VimwikiMarkdown
 
     def fixtags(template)
       @template = template.gsub('%title%',title).gsub('%pygments%',pygments_wrapped_in_tags)
+      @template = @template.gsub('%root_path%', root_path)
     end
 
     def pygments_wrapped_in_tags
       "<style type=\"text/css\">
         #{Pygments.css('.highlight')}
       </style>"
+    end
+
+    def root_path
+      options.root_path
     end
 
     def title

--- a/lib/vimwiki_markdown/version.rb
+++ b/lib/vimwiki_markdown/version.rb
@@ -1,3 +1,3 @@
 module VimwikiMarkdown
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/spec/lib/vimwiki_markdown/template_spec.rb
+++ b/spec/lib/vimwiki_markdown/template_spec.rb
@@ -30,5 +30,19 @@ module VimwikiMarkdown
         expect { Template.new(options).to_s }.to raise_exception(MissingRequiredParamError)
       end
     end
+
+    context "using %root_path%" do
+      before do
+        allow(Options).to receive(:arguments).and_return(Options::DEFAULTS)
+      end
+
+      it "correctly substitute %root_path%" do
+        allow(File).to receive(:open).with(options.template_filename,"r").and_return(StringIO.new(wiki_template))
+
+        rendered_template = Template.new(options).to_s
+        expect(rendered_template).not_to include("%root_path%")
+        expect(rendered_template).to include("./rootStyle.css")
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -121,6 +121,10 @@ def wiki_template
     <link type="text/css" rel="stylesheet" href="./overrides.css" />
     <link type="text/css" rel="stylesheet" href="./styles/shCore.css" />
     <link type="text/css" rel="stylesheet" href="./styles/shThemeDefault.css" />
+
+    <!-- for testing %ROOT_PATH% substitutions -->
+    <link type="text/css" rel="stylesheet" href="%root_path%/rootStyle.css" />
+
     <script type="text/javascript" src="./scripts/shCore.js"></script>
     <script type="text/javascript" src="./scripts/shBrushRuby.js"></script>
     <script type="text/javascript" src="./scripts/shObjectiveC.js"></script>


### PR DESCRIPTION
I want to use a simple stylesheet link tag, like: `<link rel="Stylesheet" type="text/css" href="%root_path%/style.css" />`, this PR support to vimwiki_markdown to replace root_path in the template
