### PR TITLE
Allows directories to be linked to.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+## 0.2.4 [Jan 01 2017]
+Make directory links work correctly. If you now link to
+a directory [somedir](somedir/) then that link will be preserved
+correctly.
+
 ## 0.2.3 [December 15th 2016]
 Bugfix - multiple links on the same line were not processed correctly.
 

--- a/lib/vimwiki_markdown/options.rb
+++ b/lib/vimwiki_markdown/options.rb
@@ -45,7 +45,7 @@ module VimwikiMarkdown
     def initialize
       @force = arguments[FORCE] == "1" ? true : false
       @syntax = arguments[SYNTAX]
-      @extension = arguments[EXTENSION]
+      @extension = ".#{arguments[EXTENSION]}"
       @output_dir = arguments[OUTPUT_DIR]
       @input_file = arguments[INPUT_FILE]
       @css_file = arguments[CSS_FILE]

--- a/lib/vimwiki_markdown/version.rb
+++ b/lib/vimwiki_markdown/version.rb
@@ -1,3 +1,3 @@
 module VimwikiMarkdown
-  VERSION = "0.2.3"
+  VERSION = "0.2.4"
 end

--- a/lib/vimwiki_markdown/vimwiki_link.rb
+++ b/lib/vimwiki_markdown/vimwiki_link.rb
@@ -37,16 +37,16 @@ module VimwikiMarkdown
     end
 
     def vimwiki_markdown_file_exists?
-      File.exist?(source_markdown_directory + uri) ||
-      File.exist?(source_markdown_directory + "#{uri}.#{markdown_extension}") ||
-      absolute_path_exists?
+      File.exist?((source_markdown_directory + uri).sub_ext(markdown_extension)) ||
+      absolute_path_to_markdown_file_exists?
     end
 
-    def absolute_path_exists?
+    def absolute_path_to_markdown_file_exists?
       path = Pathname(uri)
-      path.absolute? && (
-        File.exist?(source_markdown_directory + root_path + path.to_s.sub(/^\//,"")) ||
-        File.exist?(source_markdown_directory + root_path + path.to_s.sub(/^\//,"").sub(/$/, ".#{markdown_extension}")))
+      filepath = Pathname.new(source_markdown_directory + root_path + path.to_s.sub(/^\//,"")).
+                 sub_ext(markdown_extension)
+
+      path.absolute? && File.exist?(filepath)
     end
   end
 end

--- a/spec/lib/vimwiki_markdown/vimwiki_link_spec.rb
+++ b/spec/lib/vimwiki_markdown/vimwiki_link_spec.rb
@@ -4,7 +4,7 @@ module VimwikiMarkdown
   describe VimwikiLink do
     let(:markdown_link) { "[title](http://www.google.com)" }
     let(:source_filepath) { "unimportant" }
-    let(:markdown_extension) { "md" }
+    let(:markdown_extension) { ".md" }
     let(:root_path) { "-" }
 
     it "should leave external links alone" do
@@ -14,8 +14,8 @@ module VimwikiMarkdown
     end
 
     context "with an existing markdown file matching name" do
-      let(:existing_file) { "test.#{markdown_extension}" }
-      let(:existing_file_no_extension) { existing_file.gsub(/\.#{markdown_extension}$/,"") }
+      let(:existing_file) { "test#{markdown_extension}" }
+      let(:existing_file_no_extension) { existing_file.gsub(/#{markdown_extension}$/,"") }
       let(:temp_wiki_dir) { Pathname.new(Dir.mktmpdir("temp_wiki_")) }
       let(:markdown_link) { "[test](#{existing_file})" }
       let(:source_filepath) { temp_wiki_dir + "index.md" }
@@ -52,6 +52,14 @@ module VimwikiMarkdown
           expect(link.title).to eq("test")
           expect(link.uri).to eq("#{existing_file_no_extension}.html")
         end
+
+        it "must convert directory links correctly" do
+          markdown_link =  "[subdirectory](subdirectory/)"
+          link = VimwikiLink.new(markdown_link, source_filepath, markdown_extension, root_path)
+          expect(link.title).to eq("subdirectory")
+          expect(link.uri).to eq("subdirectory/")
+        end
+
       end
 
       context "../ style links" do


### PR DESCRIPTION
This is basically a bugfix whereby directories
were turned into a .html link. That is, if you
had a link like this [dir](dir/) it would
ultimately turn into <a href="dir.html">dir</a>

This fixes it so that directories can be linked to.
Basically we ensure that the filename _is_ a markdown
file, and in that case we do alter the linked file
to be .html extension. Any other files are ignored.

Fixes #4 