### PR TITLE
Make current directory root_path end with a slash

### DIFF
--- a/lib/vimwiki_markdown/options.rb
+++ b/lib/vimwiki_markdown/options.rb
@@ -53,7 +53,7 @@ module VimwikiMarkdown
       @template_default = arguments[TEMPLATE_DEFAULT]
       @template_ext = arguments[TEMPLATE_EXT]
       @root_path = arguments[ROOT_PATH]
-      @root_path = "." if @root_path == "-"
+      @root_path = "./" if @root_path == "-"
       raise "Must be markdown" unless syntax == 'markdown'
     end
 

--- a/lib/vimwiki_markdown/version.rb
+++ b/lib/vimwiki_markdown/version.rb
@@ -1,3 +1,3 @@
 module VimwikiMarkdown
-  VERSION = "0.2.4"
+  VERSION = "0.2.5"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -123,7 +123,7 @@ def wiki_template
     <link type="text/css" rel="stylesheet" href="./styles/shThemeDefault.css" />
 
     <!-- for testing %ROOT_PATH% substitutions -->
-    <link type="text/css" rel="stylesheet" href="%root_path%/rootStyle.css" />
+    <link type="text/css" rel="stylesheet" href="%root_path%rootStyle.css" />
 
     <script type="text/javascript" src="./scripts/shCore.js"></script>
     <script type="text/javascript" src="./scripts/shBrushRuby.js"></script>


### PR DESCRIPTION
This makes all values of root_path end with a slash.

This PR results in consistent paths like

```
./
../
../../
../../../
etc
```

instead of

```
.
../
../../
../../../
etc
```

We do not have to compensate with `%root_path%/` which would create double slashes.