### PR TITLE
Custom template support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ to [this commit](https://github.com/patrickdavey/vimwiki_markdown/commit/8645883
 It will get rewritten with the relative path to the root
 of the site (e.g. `./` or `../../` etc)
 
+#### Using Custom Template Tag
+
+Including a line with `%template <template name>` in any of your Vimwiki pages will will force the generator to use `<template name>.tpl` rather than `default.tpl` for that page.
+
+`<template name>` cannot contain any spaces
+
+#### Using Custom Title Tag
+
+Including a line with `%title <title name>` in any of your Vimwiki pages will force the generator to replace `%title%` in your template file with `<title name>` rather than the name of the file itself.
+*You can have spaces in your titles now!*
+
 ## Contributing
 
 Pull requests are very welcome, especially if you want to implement some of the

--- a/lib/vimwiki_markdown/options.rb
+++ b/lib/vimwiki_markdown/options.rb
@@ -26,7 +26,7 @@ module VimwikiMarkdown
 
     attr_reader :force, :syntax, :extension, :output_dir,
                 :input_file, :css_file, :template_path,
-                :template_default, :template_ext, :root_path
+                :template_default, :template_ext, :root_path, :tags
 
 =begin  force : [0/1] overwrite an existing file
           syntax : the syntax chosen for this wiki
@@ -54,10 +54,26 @@ module VimwikiMarkdown
       @template_ext = arguments[TEMPLATE_EXT]
       @root_path = arguments[ROOT_PATH]
       @root_path = "./" if @root_path == "-"
+      @tags = pull_tags
       raise "Must be markdown" unless syntax == 'markdown'
     end
 
+    def get_file_contents
+      file = File.open(input_file, "r")
+      file.read
+    end
+
+    def pull_tags
+      tags = Hash.new
+      get_file_contents.split("\n").each do |li|
+        tags['template'] = li.split.last if (li[/%template \S+./])
+        tags['title'] = li.sub(/%title /, '') if (li[/%title .+/])
+      end
+      return tags
+    end
+
     def template_filename
+      return "#{template_path}#{tags['template']}#{template_ext}" if @tags['template']
       "#{template_path}#{template_default}#{template_ext}"
     end
 
@@ -66,11 +82,12 @@ module VimwikiMarkdown
     end
 
     def title
+      return File.basename(tags['title'], ".md").split(/ |\_/).map(&:capitalize).join(" ") if @tags['title']
       File.basename(input_file, ".md").capitalize
     end
 
     def output_fullpath
-      "#{output_dir}#{title.parameterize}.html"
+      "#{output_dir}#{File.basename(input_file, ".md")}.html"
     end
 
     private

--- a/lib/vimwiki_markdown/wiki_body.rb
+++ b/lib/vimwiki_markdown/wiki_body.rb
@@ -13,6 +13,7 @@ class VimwikiMarkdown::WikiBody
   def to_s
     @markdown_body = get_wiki_markdown_contents
     fixlinks
+    remove_tags
     github_markup = GitHub::Markup.render('README.markdown', markdown_body)
     pipeline = HTML::Pipeline.new [
       HTML::Pipeline::SyntaxHighlightFilter,
@@ -57,6 +58,15 @@ class VimwikiMarkdown::WikiBody
   def convert_markdown_local_links!
     @markdown_body = @markdown_body.gsub(/\[.*?\]\(.*?\)/) do |match|
       VimwikiMarkdown::VimwikiLink.new(match, options.input_file, options.extension, options.root_path).to_s
+    end
+  end
+
+  def remove_tags
+    @markdown_body.gsub!(/%template \S+/) do
+      ""
+    end
+    @markdown_body.gsub!(/%title \S+/) do
+      ""
     end
   end
 

--- a/spec/lib/vimwiki_markdown/options_spec.rb
+++ b/spec/lib/vimwiki_markdown/options_spec.rb
@@ -3,17 +3,31 @@ require 'vimwiki_markdown/options'
 
 module VimwikiMarkdown
   describe Options do
-    subject { Options.new }
+    let(:markdown_file_content) {wiki_template_title_markdown}
+    let(:options) { Options.new }
+    subject {options}
 
     context "no options passed" do
       before do
+        allow(File).to receive(:open).and_return(StringIO.new("# title \n ## subtitle"))
         allow(Options).to receive(:arguments).and_return(Options::DEFAULTS)
       end
 
       its(:force) { should be(true) }
       its(:syntax) { should eq('markdown') }
-      its(:output_fullpath) { should eq("#{subject.output_dir}#{subject.title.parameterize}.html") }
+      its(:output_fullpath) { should eq("#{subject.output_dir}#{File.basename(subject.input_file, ".md")}.html") }
       its(:template_filename) { should eq('~/vimwiki/templates/default.tpl') }
     end
+
+    context "file with tags in it" do
+      before do
+        allow(File).to receive(:open).and_return(StringIO.new(markdown_file_content))
+        allow(Options).to receive(:arguments).and_return(Options::DEFAULTS)
+      end
+
+      its(:template_filename) { should eq('~/vimwiki/templates/alt_template.tpl') }
+      its(:title) { should eq('Super Cool Title')}
+    end
+
   end
 end

--- a/spec/lib/vimwiki_markdown/template_spec.rb
+++ b/spec/lib/vimwiki_markdown/template_spec.rb
@@ -7,11 +7,13 @@ require 'rspec-html-matchers'
 module VimwikiMarkdown
   describe Template do
     let(:options) { Options.new }
+    let(:markdown_file_content) {wiki_index_markdown}
 
     context "template" do
 
       subject { Template.new(options).to_s }
       before do
+        allow(File).to receive(:open).and_return(StringIO.new(markdown_file_content))
         allow(Options).to receive(:arguments).and_return(Options::DEFAULTS)
         allow(File).to receive(:open).with(options.template_filename,"r").and_return(StringIO.new(wiki_template))
       end
@@ -22,6 +24,7 @@ module VimwikiMarkdown
 
     context "missing pygments" do
       before do
+        allow(File).to receive(:open).and_return(StringIO.new(markdown_file_content))
         allow(Options).to receive(:arguments).and_return(Options::DEFAULTS)
       end
 
@@ -33,6 +36,7 @@ module VimwikiMarkdown
 
     context "using %root_path%" do
       before do
+        allow(File).to receive(:open).and_return(StringIO.new(markdown_file_content))
         allow(Options).to receive(:arguments).and_return(Options::DEFAULTS)
       end
 

--- a/spec/lib/vimwiki_markdown/wiki_body_spec.rb
+++ b/spec/lib/vimwiki_markdown/wiki_body_spec.rb
@@ -38,6 +38,18 @@ module VimwikiMarkdown
       expect(wiki_body.to_s).to match(/<a href="here.html">here<\/a>/)
       expect(wiki_body.to_s).to match(/<a href="there.html">there<\/a>/)
     end
+
+    it "must remove template tags" do
+      allow(wiki_body).to receive(:get_wiki_markdown_contents).and_return("%template test\n")
+      expect(wiki_body.to_s).not_to match(/%template/)
+      expect(wiki_body.to_s).not_to match(/test/)
+    end
+
+    it "must remove title tags" do
+      allow(wiki_body).to receive(:get_wiki_markdown_contents).and_return("%title test\n")
+      expect(wiki_body.to_s).not_to match(/%title/)
+      expect(wiki_body.to_s).not_to match(/test/)
+    end
   end
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -110,6 +110,16 @@ def wiki_index_markdown
 "
 end
 
+def wiki_template_title_markdown
+"
+%title super cool title\n
+%template alt_template\n
+## Todo\n
+  1. add template functionality\n
+  2. add title functionality\n
+"
+end
+
 def wiki_template
 <<-WIKITEMPLATE
 <!DOCTYPE html>


### PR DESCRIPTION
I've added template and title tag functionality. If any of your vimwiki pages contain `%template` or `%title` the template and title will be changed in the HTML output. 

I did this mainly because I wanted my index.html file to be generated using a different template that didn't have a link to Index.html or a big Index at the top. I threw the title tag functionality in there for fun, I figured I would probably want to use it later.

It has been awhile since I've used Ruby, so if I did anything wrong, please let me know.