### PR TITLE
Use extension attribute to determine how to prune file name

### DIFF
--- a/lib/vimwiki_markdown/options.rb
+++ b/lib/vimwiki_markdown/options.rb
@@ -82,12 +82,12 @@ module VimwikiMarkdown
     end
 
     def title
-      return File.basename(tags['title'], ".md").split(/ |\_/).map(&:capitalize).join(" ") if @tags['title']
-      File.basename(input_file, ".md").capitalize
+      return File.basename(tags['title'], "#{extension}").split(/ |\_/).map(&:capitalize).join(" ") if @tags['title']
+      File.basename(input_file, "#{extension}").capitalize
     end
 
     def output_fullpath
-      "#{output_dir}#{File.basename(input_file, ".md")}.html"
+      "#{output_dir}#{File.basename(input_file, "#{extension}")}.html"
     end
 
     private


### PR DESCRIPTION
When saving Markdown files with an extension other than .md, such as
.wiki, their extensions were not pruned when converting to html.  For
example, the file index.wiki was converted to index.wiki.html.