### PR TITLE
Update markdown gems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
+before_install:
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
 language: ruby
 rvm:
-  - 2.3.1
+  - 2.3.8
+  - 2.4.2
+  - 2.5.3
+  - 2.6.1

--- a/README.md
+++ b/README.md
@@ -60,17 +60,6 @@ to [this commit](https://github.com/patrickdavey/vimwiki_markdown/commit/8645883
 It will get rewritten with the relative path to the root
 of the site (e.g. `./` or `../../` etc)
 
-#### Using Custom Template Tag
-
-Including a line with `%template <template name>` in any of your Vimwiki pages will will force the generator to use `<template name>.tpl` rather than `default.tpl` for that page.
-
-`<template name>` cannot contain any spaces
-
-#### Using Custom Title Tag
-
-Including a line with `%title <title name>` in any of your Vimwiki pages will force the generator to replace `%title%` in your template file with `<title name>` rather than the name of the file itself.
-*You can have spaces in your titles now!*
-
 ## Contributing
 
 Pull requests are very welcome, especially if you want to implement some of the

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,17 @@
+## 0.3.0 [March 10 2019]
+Rebuilds vimwiki_markdown against the latest versions of Github/Markup etc.
+
+The tools are somewhat different and so it's quite possible there will be breaking changes here, especially if
+you have embedded HTML tags inside your markdown files. With a later version of https://github.com/github/markup
+we should be able to pass options to commonmark and give ourselves more options.
+
+This also uses rouge for syntax highlighting (fenced code blocks). Finding the documentation for that was fun ;)
+
+### Breaking changes with 0.3
+* This removes the title tag functionality which was introduced in 0.2.6 Unfortunately, having spaces in links meant that the new markdown parsing did not see the link as being valid (at least for [foo bar](foo bar) links). This may be reintroduced later.
+* Requires ruby >= 2.3.8
+
+
 ## 0.2.6 [Jan 18 2018]
 Add %template and %title options
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+## 0.3.1 [March 10 2019]
+Adds the ability to strip the extension correctly from vimwiki files.
+For example, the file index.wiki was converted to index.wiki.html.
+
+Thanks to @bowmanat for the PR.
+
+This may also very likely break existing links, so, watch out there ;)
+
 ## 0.3.0 [March 10 2019]
 Rebuilds vimwiki_markdown against the latest versions of Github/Markup etc.
 

--- a/lib/vimwiki_markdown/options.rb
+++ b/lib/vimwiki_markdown/options.rb
@@ -26,7 +26,7 @@ module VimwikiMarkdown
 
     attr_reader :force, :syntax, :extension, :output_dir,
                 :input_file, :css_file, :template_path,
-                :template_default, :template_ext, :root_path, :tags
+                :template_default, :template_ext, :root_path
 
 =begin  force : [0/1] overwrite an existing file
           syntax : the syntax chosen for this wiki
@@ -54,26 +54,10 @@ module VimwikiMarkdown
       @template_ext = arguments[TEMPLATE_EXT]
       @root_path = arguments[ROOT_PATH]
       @root_path = "./" if @root_path == "-"
-      @tags = pull_tags
       raise "Must be markdown" unless syntax == 'markdown'
     end
 
-    def get_file_contents
-      file = File.open(input_file, "r")
-      file.read
-    end
-
-    def pull_tags
-      tags = Hash.new
-      get_file_contents.split("\n").each do |li|
-        tags['template'] = li.split.last if (li[/%template \S+./])
-        tags['title'] = li.sub(/%title /, '') if (li[/%title .+/])
-      end
-      return tags
-    end
-
     def template_filename
-      return "#{template_path}#{tags['template']}#{template_ext}" if @tags['template']
       "#{template_path}#{template_default}#{template_ext}"
     end
 
@@ -82,12 +66,11 @@ module VimwikiMarkdown
     end
 
     def title
-      return File.basename(tags['title'], ".md").split(/ |\_/).map(&:capitalize).join(" ") if @tags['title']
       File.basename(input_file, ".md").capitalize
     end
 
     def output_fullpath
-      "#{output_dir}#{File.basename(input_file, ".md")}.html"
+      "#{output_dir}#{title.parameterize}.html"
     end
 
     private

--- a/lib/vimwiki_markdown/options.rb
+++ b/lib/vimwiki_markdown/options.rb
@@ -66,11 +66,15 @@ module VimwikiMarkdown
     end
 
     def title
-      File.basename(input_file, ".md").capitalize
+      File.basename(input_file, "#{extension}").capitalize
     end
 
     def output_fullpath
-      "#{output_dir}#{title.parameterize}.html"
+      "#{output_dir}#{File.basename(input_file, "#{extension}")}.html"
+    end
+
+    def output_fullpath
+      "#{output_dir}#{File.basename(input_file, "#{extension}")}.html"
     end
 
     private

--- a/lib/vimwiki_markdown/template.rb
+++ b/lib/vimwiki_markdown/template.rb
@@ -1,5 +1,4 @@
-require 'pygments.rb'
-
+require 'rouge'
 module VimwikiMarkdown
   class Template
 
@@ -31,7 +30,7 @@ module VimwikiMarkdown
 
     def pygments_wrapped_in_tags
       "<style type=\"text/css\">
-        #{Pygments.css('.highlight')}
+        #{::Rouge::Themes::Github.render(scope: '.highlight')}
       </style>"
     end
 

--- a/lib/vimwiki_markdown/version.rb
+++ b/lib/vimwiki_markdown/version.rb
@@ -1,3 +1,3 @@
 module VimwikiMarkdown
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end

--- a/lib/vimwiki_markdown/version.rb
+++ b/lib/vimwiki_markdown/version.rb
@@ -1,3 +1,3 @@
 module VimwikiMarkdown
-  VERSION = "0.2.6"
+  VERSION = "0.3.0"
 end

--- a/lib/vimwiki_markdown/wiki_body.rb
+++ b/lib/vimwiki_markdown/wiki_body.rb
@@ -14,12 +14,15 @@ class VimwikiMarkdown::WikiBody
     @markdown_body = get_wiki_markdown_contents
     fixlinks
     remove_tags
-    github_markup = GitHub::Markup.render('README.markdown', markdown_body)
-    pipeline = HTML::Pipeline.new [
+    html = GitHub::Markup.render_s(
+      GitHub::Markups::MARKUP_MARKDOWN,
+      markdown_body
+    )
+    pipeline = HTML::Pipeline.new([
       HTML::Pipeline::SyntaxHighlightFilter,
       HTML::Pipeline::TableOfContentsFilter
-    ]
-    result = pipeline.call(github_markup)
+    ], { scope: "highlight"})
+    result = pipeline.call(html)
     result[:output].to_s
   end
 

--- a/lib/vimwiki_markdown/wiki_body.rb
+++ b/lib/vimwiki_markdown/wiki_body.rb
@@ -13,7 +13,6 @@ class VimwikiMarkdown::WikiBody
   def to_s
     @markdown_body = get_wiki_markdown_contents
     fixlinks
-    remove_tags
     html = GitHub::Markup.render_s(
       GitHub::Markups::MARKUP_MARKDOWN,
       markdown_body
@@ -61,15 +60,6 @@ class VimwikiMarkdown::WikiBody
   def convert_markdown_local_links!
     @markdown_body = @markdown_body.gsub(/\[.*?\]\(.*?\)/) do |match|
       VimwikiMarkdown::VimwikiLink.new(match, options.input_file, options.extension, options.root_path).to_s
-    end
-  end
-
-  def remove_tags
-    @markdown_body.gsub!(/%template \S+/) do
-      ""
-    end
-    @markdown_body.gsub!(/%title \S+/) do
-      ""
     end
   end
 

--- a/spec/lib/vimwiki_markdown/options_spec.rb
+++ b/spec/lib/vimwiki_markdown/options_spec.rb
@@ -14,6 +14,25 @@ module VimwikiMarkdown
       its(:syntax) { should eq('markdown') }
       its(:output_fullpath) { should eq("#{subject.output_dir}#{subject.title.parameterize}.html") }
       its(:template_filename) { should eq('~/vimwiki/templates/default.tpl') }
+
+      describe "extension" do
+        it "deals with a different wiki extension correctly" do
+          allow(Options).to receive(:arguments).and_return(
+            ["1", #force - 1/0
+             "markdown",
+             "wiki",
+             "~/vimwiki/site_html/",
+             "~/vimwiki/index.wiki",
+             "~/vimwiki/site_html/style.css",
+             "~/vimwiki/templates/",
+             "default",
+             ".tpl",
+             "-"]
+          )
+
+          expect(Options.new.title).to eq("Index")
+        end
+      end
     end
   end
 end

--- a/spec/lib/vimwiki_markdown/options_spec.rb
+++ b/spec/lib/vimwiki_markdown/options_spec.rb
@@ -3,31 +3,17 @@ require 'vimwiki_markdown/options'
 
 module VimwikiMarkdown
   describe Options do
-    let(:markdown_file_content) {wiki_template_title_markdown}
-    let(:options) { Options.new }
-    subject {options}
+    subject { Options.new }
 
     context "no options passed" do
       before do
-        allow(File).to receive(:open).and_return(StringIO.new("# title \n ## subtitle"))
         allow(Options).to receive(:arguments).and_return(Options::DEFAULTS)
       end
 
       its(:force) { should be(true) }
       its(:syntax) { should eq('markdown') }
-      its(:output_fullpath) { should eq("#{subject.output_dir}#{File.basename(subject.input_file, ".md")}.html") }
+      its(:output_fullpath) { should eq("#{subject.output_dir}#{subject.title.parameterize}.html") }
       its(:template_filename) { should eq('~/vimwiki/templates/default.tpl') }
     end
-
-    context "file with tags in it" do
-      before do
-        allow(File).to receive(:open).and_return(StringIO.new(markdown_file_content))
-        allow(Options).to receive(:arguments).and_return(Options::DEFAULTS)
-      end
-
-      its(:template_filename) { should eq('~/vimwiki/templates/alt_template.tpl') }
-      its(:title) { should eq('Super Cool Title')}
-    end
-
   end
 end

--- a/spec/lib/vimwiki_markdown/template_spec.rb
+++ b/spec/lib/vimwiki_markdown/template_spec.rb
@@ -7,13 +7,11 @@ require 'rspec-html-matchers'
 module VimwikiMarkdown
   describe Template do
     let(:options) { Options.new }
-    let(:markdown_file_content) {wiki_index_markdown}
 
     context "template" do
 
       subject { Template.new(options).to_s }
       before do
-        allow(File).to receive(:open).and_return(StringIO.new(markdown_file_content))
         allow(Options).to receive(:arguments).and_return(Options::DEFAULTS)
         allow(File).to receive(:open).with(options.template_filename,"r").and_return(StringIO.new(wiki_template))
       end
@@ -24,7 +22,6 @@ module VimwikiMarkdown
 
     context "missing pygments" do
       before do
-        allow(File).to receive(:open).and_return(StringIO.new(markdown_file_content))
         allow(Options).to receive(:arguments).and_return(Options::DEFAULTS)
       end
 
@@ -36,7 +33,6 @@ module VimwikiMarkdown
 
     context "using %root_path%" do
       before do
-        allow(File).to receive(:open).and_return(StringIO.new(markdown_file_content))
         allow(Options).to receive(:arguments).and_return(Options::DEFAULTS)
       end
 

--- a/spec/lib/vimwiki_markdown/wiki_body_spec.rb
+++ b/spec/lib/vimwiki_markdown/wiki_body_spec.rb
@@ -13,6 +13,7 @@ module VimwikiMarkdown
       allow(wiki_body).to receive(:get_wiki_markdown_contents).and_return(markdown_file_content)
       allow_any_instance_of(VimwikiMarkdown::VimwikiLink).to receive(:vimwiki_markdown_file_exists?).and_return(true)
       expect(wiki_body.to_s).to match(/<a href="books.html">Books<\/a>/)
+      expect(wiki_body.to_s).to match(/<a href="bash-tips.html">Bash Tips<\/a>/)
     end
 
     it "must convert wiki links with separate titles correctly" do

--- a/spec/lib/vimwiki_markdown/wiki_body_spec.rb
+++ b/spec/lib/vimwiki_markdown/wiki_body_spec.rb
@@ -39,18 +39,6 @@ module VimwikiMarkdown
       expect(wiki_body.to_s).to match(/<a href="there.html">there<\/a>/)
     end
 
-    it "must remove template tags" do
-      allow(wiki_body).to receive(:get_wiki_markdown_contents).and_return("%template test\n")
-      expect(wiki_body.to_s).not_to match(/%template/)
-      expect(wiki_body.to_s).not_to match(/test/)
-    end
-
-    it "must remove title tags" do
-      allow(wiki_body).to receive(:get_wiki_markdown_contents).and_return("%title test\n")
-      expect(wiki_body.to_s).not_to match(/%title/)
-      expect(wiki_body.to_s).not_to match(/test/)
-    end
-
     describe "syntax highlighting" do
       it "must give correct classes" do
         allow(wiki_body).to receive(:get_wiki_markdown_contents)

--- a/spec/lib/vimwiki_markdown/wiki_body_spec.rb
+++ b/spec/lib/vimwiki_markdown/wiki_body_spec.rb
@@ -50,6 +50,13 @@ module VimwikiMarkdown
       expect(wiki_body.to_s).not_to match(/%title/)
       expect(wiki_body.to_s).not_to match(/test/)
     end
-  end
 
+    describe "syntax highlighting" do
+      it "must give correct classes" do
+        allow(wiki_body).to receive(:get_wiki_markdown_contents)
+          .and_return("```bash\n  find ./path -type f -exec sed -i 's/find_this/replace_this/g' {} \\;\n```\n")
+        expect(wiki_body.to_s).to match(/highlight/)
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -110,16 +110,6 @@ def wiki_index_markdown
 "
 end
 
-def wiki_template_title_markdown
-"
-%title super cool title\n
-%template alt_template\n
-## Todo\n
-  1. add template functionality\n
-  2. add title functionality\n
-"
-end
-
 def wiki_template
 <<-WIKITEMPLATE
 <!DOCTYPE html>

--- a/vimwiki_markdown.gemspec
+++ b/vimwiki_markdown.gemspec
@@ -19,17 +19,17 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.6"
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rake", "~> 11.2"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "pry", ">= 0.9.12"
-  spec.add_development_dependency "rspec-its", "~> 1.1.0"
+  spec.add_development_dependency "pry", "~> 0.12"
+  spec.add_development_dependency "rspec-its", "~> 1.1"
   spec.add_development_dependency "rspec-html-matchers", "~> 0.6.1"
   spec.add_development_dependency "guard-rspec", "~> 4.3"
 
-  spec.add_runtime_dependency     "activesupport", "~> 4.1.6"
-  spec.add_runtime_dependency     "github-markup", "~> 1.3.0"
-  spec.add_runtime_dependency     "github-markdown", "~> 0.6.8"
-  spec.add_runtime_dependency     "github-linguist", "~> 3.1.5"
-  spec.add_runtime_dependency     "redcarpet", "~> 3.1.2"
-  spec.add_runtime_dependency     "html-pipeline", "~> 1.11.0"
+  spec.add_runtime_dependency     "activesupport", "~> 4.1"
+  spec.add_runtime_dependency     "github-markup", "~> 3.0"
+  spec.add_runtime_dependency     "commonmarker", "~> 0.18.0"
+  spec.add_runtime_dependency     "html-pipeline", "~> 2.0"
+  spec.add_runtime_dependency     "rouge", "~> 3.3"
+  spec.add_runtime_dependency     "escape_utils", "~> 1.2"
 end

--- a/vimwiki_markdown.gemspec
+++ b/vimwiki_markdown.gemspec
@@ -12,13 +12,13 @@ Gem::Specification.new do |spec|
   spec.description   = %q{Converts a vimwiki markdown file to html.  It parses [[links]] and has support for syntax highlighting.}
   spec.homepage      = "https://github.com/patrickdavey/wimwiki_markdown"
   spec.license       = "MIT"
-  spec.required_ruby_version = '>= 1.9.3'
+  spec.required_ruby_version = '>= 2.3.8'
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_development_dependency "bundler", "~> 1.0"
   spec.add_development_dependency "rake", "~> 11.2"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry", "~> 0.12"


### PR DESCRIPTION
This PR updates the underlying gems we depend on (https://github.com/github/markup etc) to be their latest versions. It removes the dependency on rugged, which should fix #14 as well. It removes the dependency on pygments, so, no more dependency on python.

Unfortunately, I wasn't able to nicely keep the [tags functionality](https://github.com/patrickdavey/vimwiki_markdown/commit/0644ac831466158006b9c91a1b9b5e1c8ce3dc0a) introduced by @KTSCode . The reason for this is that we're using the github/markup gem, and, at the moment there's no way to pass options through to the `commonmark` gem. Unfortunately, common mark doesn't like links with spaces. So, while it'll happily change [android](android.html) into a link, it won't do it for [foo bar](foo bar.html). At least, not as far as I can see.

@KTSCode I'm probably going to release this version (0.3.0) with your tags functionality removed. I'm sorry to do that, however, it's about time to bump the dependencies up to modern versions.  If the github/markup gem is updated, then I may revisit the `tags` functionality. If you have time to make another PR with updated code, that would also be great.