### PR TITLE
Issue 18 tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ to [this commit](https://github.com/patrickdavey/vimwiki_markdown/commit/8645883
 It will get rewritten with the relative path to the root
 of the site (e.g. `./` or `../../` etc)
 
+#### Optional %date% marker.
+
+You can also have a `%date%` marker in your template file
+It will get rewritten with todays date in the format 29 March 2019
+
+#### Optional %nohtml
+
+If you place the text %nohtml anywhere in a wiki page, it will not be processed into html
+
 ## Contributing
 
 Pull requests are very welcome, especially if you want to implement some of the

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+## 0.3.3 [March 29 2019]
+Support for %date% and %nohtml tags
+
 ## 0.3.2 [March 28 2019]
 
 Bugfix

--- a/lib/vimwiki_markdown.rb
+++ b/lib/vimwiki_markdown.rb
@@ -12,6 +12,9 @@ module VimwikiMarkdown
     options = Options.new
     template_html = Template.new(options)
     body_html = WikiBody.new(options)
+
+    return if body_html.to_s =~ /%nohtml/
+
     combined_body_template = template_html.to_s.gsub('%content%', body_html.to_s)
 
     File.write(options.output_fullpath, combined_body_template)

--- a/lib/vimwiki_markdown/template.rb
+++ b/lib/vimwiki_markdown/template.rb
@@ -1,4 +1,6 @@
 require 'rouge'
+require 'date'
+
 module VimwikiMarkdown
   class Template
 
@@ -24,8 +26,10 @@ module VimwikiMarkdown
     end
 
     def fixtags(template)
-      @template = template.gsub('%title%',title).gsub('%pygments%',pygments_wrapped_in_tags)
-      @template = @template.gsub('%root_path%', root_path)
+      @template = template.gsub('%title%',title)
+                          .gsub('%pygments%',pygments_wrapped_in_tags)
+                          .gsub('%root_path%', root_path)
+                          .gsub('%date%', Date.today.strftime("%e %b %Y"))
     end
 
     def pygments_wrapped_in_tags

--- a/lib/vimwiki_markdown/version.rb
+++ b/lib/vimwiki_markdown/version.rb
@@ -1,3 +1,3 @@
 module VimwikiMarkdown
-  VERSION = "0.3.2"
+  VERSION = "0.3.3"
 end

--- a/lib/vimwiki_markdown/wiki_body.rb
+++ b/lib/vimwiki_markdown/wiki_body.rb
@@ -62,5 +62,4 @@ class VimwikiMarkdown::WikiBody
       VimwikiMarkdown::VimwikiLink.new(match, options.input_file, options.extension, options.root_path).to_s
     end
   end
-
 end

--- a/spec/lib/vimwiki_markdown/template_spec.rb
+++ b/spec/lib/vimwiki_markdown/template_spec.rb
@@ -3,6 +3,7 @@ require 'vimwiki_markdown/options'
 require 'vimwiki_markdown/template'
 require 'vimwiki_markdown/exceptions'
 require 'rspec-html-matchers'
+require 'date'
 
 module VimwikiMarkdown
   describe Template do
@@ -42,6 +43,18 @@ module VimwikiMarkdown
         rendered_template = Template.new(options).to_s
         expect(rendered_template).not_to include("%root_path%")
         expect(rendered_template).to include("./rootStyle.css")
+      end
+    end
+
+    context "using %date" do
+      before do
+        allow(Options).to receive(:arguments).and_return(Options::DEFAULTS)
+      end
+
+      it "replaces %date% with todays date" do
+        allow(File).to receive(:open).with(options.template_filename,"r").and_return(StringIO.new(wiki_template))
+        rendered_template = Template.new(options).to_s
+        expect(rendered_template).to include(Date.today.strftime("%e %b %Y"))
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -151,6 +151,7 @@ def wiki_template
     <div class="row">
       <div class="span12">
         <h2 id="title">%title%</h2>
+        <p><small>Page created on %date%</small></p>
         %content%
       </div>
     </div>


### PR DESCRIPTION
Partly addresses the tags functionality by bringing in the `%date%` and `%nohtml` tags.

It's not clear to me whether vimwiki itself expects %date or %date% ... Frankly I think it's cleaner if it's enclosed.

This does not add the ability to specify your own custom date.