### PR TITLE
Add processing for url fragments to vimwiki_link

### DIFF
--- a/lib/vimwiki_markdown/vimwiki_link.rb
+++ b/lib/vimwiki_markdown/vimwiki_link.rb
@@ -9,13 +9,14 @@
 
 module VimwikiMarkdown
   class VimwikiLink
-    MARKDOWN_LINK_REGEX = /\[(?<title>.*)\]\((?<uri>.*)\)/
+    MARKDOWN_LINK_REGEX = /\[(?<title>.*)\]\((?<uri>(?:(?!#).)*)(?<fragment>(?:#)?.*)\)/
 
-    attr_reader :title, :uri, :source_markdown_directory, :markdown_extension, :root_path
+    attr_reader :title, :uri, :fragment, :source_markdown_directory, :markdown_extension, :root_path
 
     def initialize(markdown_link, source_markdown_filepath, markdown_extension, root_path)
       @title = markdown_link.match(MARKDOWN_LINK_REGEX)[:title]
       @uri = markdown_link.match(MARKDOWN_LINK_REGEX)[:uri]
+      @fragment = markdown_link.match(MARKDOWN_LINK_REGEX)[:fragment]
       @markdown_extension = markdown_extension
       @root_path = root_path
       @source_markdown_directory = Pathname.new(source_markdown_filepath).dirname
@@ -34,6 +35,8 @@ module VimwikiMarkdown
         path = Pathname.new(uri)
         @uri = "#{path.dirname + path.basename(markdown_extension).to_s.parameterize}.html"
       end
+
+      @uri = "#{uri}#{fragment.empty? ? '' : '#' + fragment.parameterize}"
     end
 
     def vimwiki_markdown_file_exists?

--- a/spec/lib/vimwiki_markdown/vimwiki_link_spec.rb
+++ b/spec/lib/vimwiki_markdown/vimwiki_link_spec.rb
@@ -13,6 +13,14 @@ module VimwikiMarkdown
       expect(link.uri).to eq("http://www.google.com")
     end
 
+    it "should render fragment-only links correctly" do
+      markdown_link = "[test](#Wiki Heading)"
+
+      link = VimwikiLink.new(markdown_link, source_filepath, markdown_extension, root_path)
+      expect(link.title).to eq("test")
+      expect(link.uri).to eq("#wiki-heading")
+    end
+
     context "with an existing markdown file matching name" do
       let(:existing_file) { "test#{markdown_extension}" }
       let(:existing_file_no_extension) { existing_file.gsub(/#{markdown_extension}$/,"") }
@@ -42,6 +50,14 @@ module VimwikiMarkdown
         link = VimwikiLink.new(markdown_link, source_filepath, markdown_extension, root_path)
         expect(link.title).to eq("test")
         expect(link.uri).to eq("#{existing_file_no_extension}.html")
+      end
+
+      it "must convert same-directory markdown links with url fragments correctly" do
+        markdown_link = "[test](#{existing_file_no_extension}#Wiki Heading)"
+
+        link = VimwikiLink.new(markdown_link, source_filepath, markdown_extension, root_path)
+        expect(link.title).to eq("test")
+        expect(link.uri).to eq("#{existing_file_no_extension}.html#wiki-heading")
       end
 
       context "subdirectory linked files" do


### PR DESCRIPTION
Added some processing for links with url fragments, such as those generated by :VimwikiTOC or or when using a diary_caption_level >0