### PR TITLE
fix(links): handles relative links to files

### DIFF
--- a/lib/vimwiki_markdown/wiki_body.rb
+++ b/lib/vimwiki_markdown/wiki_body.rb
@@ -63,7 +63,7 @@ class VimwikiMarkdown::WikiBody
 
   def convert_markdown_local_links!
     @markdown_body = @markdown_body.gsub(/\[.*?\]\(.*?\)/) do |match|
-      VimwikiMarkdown::VimwikiLink.new(match, options.input_file, options.extension, options.root_path).to_s
+      VimwikiMarkdown::VimwikiLink.new(match, options.input_file, options.extension, options.root_path, options.output_dir).to_s
     end
   end
 


### PR DESCRIPTION
relative links to files are now handled correctly (absolute path to wiki)
this applies for any link to a file whether it is `![]()` or `[]()`
if a title is passed, it will be handled as well

solves #25