### PR TITLE
Add tasklist extension to commonmarker options

### DIFF
--- a/lib/vimwiki_markdown/wiki_body.rb
+++ b/lib/vimwiki_markdown/wiki_body.rb
@@ -70,7 +70,7 @@ class VimwikiMarkdown::WikiBody
   def hack_replace_commonmarker_proc!
     GitHub::Markup::Markdown::MARKDOWN_GEMS["commonmarker"] = proc { |content, options: {}|
       commonmarker_opts = [:GITHUB_PRE_LANG].concat(options.fetch(:commonmarker_opts, []))
-      commonmarker_exts = options.fetch(:commonmarker_exts, [:autolink, :table, :strikethrough])
+      commonmarker_exts = options.fetch(:commonmarker_exts, [:autolink, :table, :strikethrough, :tasklist])
       CommonMarker.render_html(content, commonmarker_opts, commonmarker_exts)
     }
   end


### PR DESCRIPTION
With this extension now the checkboxes are rendered
with the GitHub flavor, as described in here:
https://github.github.com/gfm/\#task-list-items-extension-

However this still puts limits on the vimwiki checklist