### PR TITLE
Use `CGI` instead of `EscapeUtils` to remove deprecation warning

### DIFF
--- a/lib/vimwiki_markdown/vimwiki_toc_filter.rb
+++ b/lib/vimwiki_markdown/vimwiki_toc_filter.rb
@@ -1,3 +1,5 @@
+require "cgi"
+
 class VimwikiTOCFilter < HTML::Pipeline::TableOfContentsFilter
   def call
     result[:toc] = String.new('')
@@ -12,7 +14,7 @@ class VimwikiTOCFilter < HTML::Pipeline::TableOfContentsFilter
       uniq = headers[id] > 1 ? "-#{headers[id]}" : ''
       headers[id] += 1
       if header_content = node.children.first
-        result[:toc] << %(<li><a href="##{id}#{uniq}">#{EscapeUtils.escape_html(text)}</a></li>\n)
+        result[:toc] << %(<li><a href="##{id}#{uniq}">#{CGI.escape_html(text)}</a></li>\n)
         header_content.add_previous_sibling(%(<a id="#{id}#{uniq}" class="anchor" href="##{id}#{uniq}" aria-hidden="true">#{anchor_icon}</a>))
       end
     end


### PR DESCRIPTION
Since Ruby 2.5, the escape methods in `CGI` were optimized to the point it makes no sense to use `EscapeUtils`, [according to the gem creator](https://github.com/brianmario/escape_utils#escape_utils). This throws a deprecation warning when compiling a markdown Vimwiki to HTML:

```
EscapeUtils.escape_html is deprecated. Use GCI.escapeHTML instead, it's faster
``` 

This commit changes `EscapeUtils.escape_html` to `CGI.escape_html`. Considering Ruby 2.5, and even 2.6, are EOL[1] I believe it's fine to simply change the call to `CGI` instead of handling older Ruby versions, etc.

Since the `html-pipeline` gem requires `escape_utils`, it isn't possible to remove the dependency from the gemspec. I might open an issue or PR there asking if it's possible to accomodate not requiring it in newer Ruby versions.

This is a minor issue, honestly, but it's annoying getting so many warnings whenever I compile (`VimwikiAll2HTML`) my large-ish personal wiki.  

[1]: https://www.ruby-lang.org/en/downloads/branches/